### PR TITLE
Ignore 'ytmusic-continuation-item-renderer' elements when scraping

### DIFF
--- a/scripts/content-scripts/utilities.js
+++ b/scripts/content-scripts/utilities.js
@@ -29,15 +29,24 @@ function scrapeElements (scrollContainer, elementContainer, scrapeStartingIndex,
             clearTimeout(scrollingTimeoutID); // Since there are still elements available to scrape, clear the timeout that would otherwise end the scrolling process after a few seconds. The timeout will be reset if the scrape isn't complete after the upcoming scrape.        
             
             for (let i = scrapeStartingIndex; i < (elementCollection.length); i++) { // For each new element loaded in the DOM...
-                results.push(scrapeElementFunction(elementCollection[i])); // Scrape the metadata from the element and add it to the metadata array
+                const elementMetadata = scrapeElementFunction(elementCollection[i]); // Scrape the metadata from the element
+
+                // if (typeof elementMetadata.title === "undefined") {
+
+                // }
+
+                if (typeof elementMetadata.title !== "undefined") {
+                    results.push(elementMetadata); // If the metadata has valid data, add it to the results array
+                }
+                //results.push(scrapeElementFunction(elementCollection[i])); // Scrape the metadata from the element and add it to the metadata array
             }
 
             if (results.length === expectedElementCount) { // If there is an expected element count and it matches the length of the metadata array...
-                // Note: This currently works for the 'Your Likes' list even though the expected/displayed track count is incorrect. This is is because the displayed track count is bigger than the actual one. If it was the other way around, it's possible the resulting scraped tracklist could be incorrect.
+                // Note: This currently works for the 'Your Likes' list even though the expected/displayed track count is incorrect. This is is because the displayed track count is greater than the actual one. If it was the other way around, it's possible the resulting scraped tracklist could be incorrect.
                 endScrape(); // End the scrape
             } else { // Else, if the scrape isn't complete or the expected element count is unknown...
                 scrollToElement(elementCollection[elementCollection.length-1]); // Scroll to the last available child element in the container
-                scrapeStartingIndex = elementCollection.length; // Set the starting index for the next scrape to be one greater than the index of the last child element from the previous scrape
+                scrapeStartingIndex = elementCollection.length-1; // Set the starting index for the next scrape to be one greater than the index of the last child element from the previous scrape
                 scrollingTimeoutID = setTimeout(endScrape, 10000); // Set a timeout to end the scrolling if no new changes to the container element have been observed for a while. This avoids infinite scrolling when the expected element count is unknown, or if an unexpected issue is encountered.
             }
         }
@@ -59,7 +68,59 @@ function scrapeElements (scrollContainer, elementContainer, scrapeStartingIndex,
     });
 }
 
-/**** Non-Global Helpers ****
+// /**
+//  * Runs through a process that scrolls through the given list of elements and scrapes metadata out of each of the elements
+//  * @param {Object} scrollContainer The element which needs to be scrolled in order to load all relevant child elements
+// * @param {Object} elementContainer The container element wrapping all the individual elements to scrape
+//  * @param {number} scrapeStartingIndex The index within the container element at which to begin the initial scrape
+//  * @param {function} scrapeElementFunction The function to execute on each individual element to extract metadata from it
+//  * @param {number} [expectedElementCount] An optional parameter indicating the expected element count for the list, if available
+//  * @returns {Object[]} An array of the metadata scraped from each element
+//  */
+// async function asyncScrapeElements(scrollContainer, elementContainer, scrapeStartingIndex, scrapeElementFunction, expectedElementCount) {
+//     const elementCollection = elementContainer.children;
+//     const results = []; // Create an array to store the metadata scraped from each element in the list
+//     let scrollingTimeoutID = undefined; // Variable tracking the timeout to end the scroll & scrape process, in case no changes to the container element are observed for a while
+
+//     const triggerDelayedScrape = (delay=100) => setTimeout(scrapeLoadedElements, delay); // Set up the function to trigger a scrape of the loaded element after a brief delay. This allows time for all the sub-elements in the DOM to load.
+
+//     const scrapeLoadedElements = () => { // Set up the function to scrape the set of elements most recently loaded in the DOM
+//         clearTimeout(scrollingTimeoutID); // Since there are still elements available to scrape, clear the timeout that would otherwise end the scrolling process after a few seconds. The timeout will be reset if the scrape isn't complete after the upcoming scrape.        
+        
+//         for (let i = scrapeStartingIndex; i < (elementCollection.length); i++) { // For each new element loaded in the DOM...
+//             results.push(scrapeElementFunction(elementCollection[i])); // Scrape the metadata from the element and add it to the metadata array
+//         }
+
+//         if (results.length === expectedElementCount) { // If there is an expected element count and it matches the length of the metadata array...
+//             // Note: This currently works for the 'Your Likes' list even though the expected/displayed track count is incorrect. This is is because the displayed track count is greater than the actual one. If it was the other way around, it's possible the resulting scraped tracklist could be incorrect.
+//             endScrape(); // End the scrape
+//         } else { // Else, if the scrape isn't complete or the expected element count is unknown...
+//             scrollToElement(elementCollection[elementCollection.length-1]); // Scroll to the last available child element in the container
+//             scrapeStartingIndex = elementCollection.length; // Set the starting index for the next scrape to be one greater than the index of the last child element from the previous scrape
+//             scrollingTimeoutID = setTimeout(endScrape, 10000); // Set a timeout to end the scrolling if no new changes to the container element have been observed for a while. This avoids infinite scrolling when the expected element count is unknown, or if an unexpected issue is encountered.
+//         }
+//     }
+
+//     const endScrape = () => { // Set up the function to execute once the scrape & scroll process has either been successfully completed or timed out
+//         allowManualScrolling(scrollContainer, true); // Allow the user to scroll manually again
+//         observer.disconnect(); // Disconnect the mutation observer
+//         return results; // Return the resulting array of scraped metadata
+//     }
+
+//     allowManualScrolling(scrollContainer, false); //Temporarily disable manual scrolling to avoid any interference from the user during the scrape process
+//     scrollToTopOfContainer(scrollContainer); //Scroll to the top of the tracklist, as an extra safety measure just to be certain that no tracks are missed in the scrape. (Note: This step likely isn't necessary in YTM since it appears the track row elements never get removed from the DOM no matter how far down a list you scroll).
+
+//     const observer = new MutationObserver(triggerDelayedScrape); // Create a new mutation observer instance which triggers a scrape of the loaded elements after a brief delay (which allows time for all the sub-elements in the DOM to load).
+//     const observerConfig = {childList: true}; // Set up the configuration options for the Mutation Observer to watch for changes to the element's childList
+//     observer.observe(elementContainer, observerConfig); // Start observing the container element for configured mutations (i.e. for any changes to its childList)
+    
+//     triggerDelayedScrape(); // Wait a short amount of time to allow the page to scroll to the top of the tracklist, and then begin the scrape & scroll process
+
+//     // await console.log("Awaiting");
+//     // console.log("awaited");
+// }
+
+/**** Helpers ****
 
 /**
  * Sets whether or not the user should be able to scroll manually within the container element provided

--- a/scripts/content-scripts/utilities.js
+++ b/scripts/content-scripts/utilities.js
@@ -31,10 +31,8 @@ function scrapeElements (scrollContainer, elementContainer, scrapeStartingIndex,
             console.info(`Current element collection length is ${elementCollection.length}`);
 
             for (let i = scrapeStartingIndex; i < elementCollection.length; i++) { // For each new element loaded in the DOM...
-                console.log(elementCollection[i].nodeName);
-                
-                // Due to how YTM currently loads track elements ~100 at a time, we ignore the 101st, 201st, etc., until the next scrape interval because these aren't properly loaded even though the element exists. It's possible this YTM behavior will change in the future.
-                if (i % 100 === 0 && i !== scrapeStartingIndex) {
+                // Ignore the "continuation" element at the end of each batch of loaded elements. It's possible this YTM behavior will change in the future.
+                if (elementCollection[i].nodeName == "YTMUSIC-CONTINUATION-ITEM-RENDERER") {
                     break;
                 }
 

--- a/scripts/content-scripts/utilities.js
+++ b/scripts/content-scripts/utilities.js
@@ -27,7 +27,6 @@ function scrapeElements (scrollContainer, elementContainer, scrapeStartingIndex,
 
         const scrapeLoadedElements = () => { // Set up the function to scrape the set of elements most recently loaded in the DOM
             clearTimeout(scrollingTimeoutID); // Since there are still elements available to scrape, clear the timeout that would otherwise end the scrolling process after a few seconds. The timeout will be reset if the scrape isn't complete after the upcoming scrape.        
-            
             console.info(`Current element collection length is ${elementCollection.length}`);
 
             let i = scrapeStartingIndex;
@@ -36,22 +35,6 @@ function scrapeElements (scrollContainer, elementContainer, scrapeStartingIndex,
                 results.push(elementMetadata); // Add the metadata to the results array
                 i++;
             }
-
-            // do {
-            //     const elementMetadata = scrapeElementFunction(elementCollection[i]); // Scrape the metadata from the element
-            //     results.push(elementMetadata); // If the metadata has valid data, add it to the results array
-            //     i++;
-            //   } while (i < elementCollection.length && elementCollection[i].nodeName != "YTMUSIC-CONTINUATION-ITEM-RENDERER");
-
-            // for (let i = scrapeStartingIndex; i < elementCollection.length; i++) { // For each new element loaded in the DOM...
-            //     // Ignore the "continuation" element at the end of each batch of loaded elements. It's possible this YTM behavior will change in the future.
-            //     if (elementCollection[i].nodeName == "YTMUSIC-CONTINUATION-ITEM-RENDERER") {
-            //         break;
-            //     }
-
-            //     const elementMetadata = scrapeElementFunction(elementCollection[i]); // Scrape the metadata from the element
-            //     results.push(elementMetadata); // If the metadata has valid data, add it to the results array
-            // }
 
             if (results.length === expectedElementCount) { // If there is an expected element count and it matches the length of the metadata array...
                 // Note: This currently works for the 'Your Likes' list even though the expected/displayed track count is incorrect. This is is because the displayed track count is greater than the actual one. If it was the other way around, it's possible the resulting scraped tracklist could be incorrect.

--- a/scripts/content-scripts/utilities.js
+++ b/scripts/content-scripts/utilities.js
@@ -31,27 +31,19 @@ function scrapeElements (scrollContainer, elementContainer, scrapeStartingIndex,
             console.info(`Current element collection length is ${elementCollection.length}`);
 
             for (let i = scrapeStartingIndex; i < elementCollection.length; i++) { // For each new element loaded in the DOM...
-                if (i === scrapeStartingIndex || i % 100 !== 0) {
-                    const elementMetadata = scrapeElementFunction(elementCollection[i]); // Scrape the metadata from the element
-                    results.push(elementMetadata); // If the metadata has valid data, add it to the results array
-
-                    if (typeof elementMetadata.title === "undefined") {
-                        console.log("problematic index is " + i);
-                    }
-                }
+                console.log(elementCollection[i].nodeName);
                 
-                // const elementMetadata = scrapeElementFunction(elementCollection[i]); // Scrape the metadata from the element
+                // Due to how YTM currently loads track elements ~100 at a time, we ignore the 101st, 201st, etc., until the next scrape interval because these aren't properly loaded even though the element exists. It's possible this YTM behavior will change in the future.
+                if (i % 100 === 0 && i !== scrapeStartingIndex) {
+                    break;
+                }
+
+                const elementMetadata = scrapeElementFunction(elementCollection[i]); // Scrape the metadata from the element
+                results.push(elementMetadata); // If the metadata has valid data, add it to the results array
 
                 // if (typeof elementMetadata.title === "undefined") {
                 //     console.log("problematic index is " + i);
                 // }
-
-                
-
-                // if (typeof elementMetadata.title !== "undefined") {
-                //     results.push(elementMetadata); // If the metadata has valid data, add it to the results array
-                // }
-                //results.push(scrapeElementFunction(elementCollection[i])); // Scrape the metadata from the element and add it to the metadata array
             }
 
             if (results.length === expectedElementCount) { // If there is an expected element count and it matches the length of the metadata array...

--- a/scripts/content-scripts/utilities.js
+++ b/scripts/content-scripts/utilities.js
@@ -30,19 +30,28 @@ function scrapeElements (scrollContainer, elementContainer, scrapeStartingIndex,
             
             console.info(`Current element collection length is ${elementCollection.length}`);
 
-            for (let i = scrapeStartingIndex; i < elementCollection.length; i++) { // For each new element loaded in the DOM...
-                // Ignore the "continuation" element at the end of each batch of loaded elements. It's possible this YTM behavior will change in the future.
-                if (elementCollection[i].nodeName == "YTMUSIC-CONTINUATION-ITEM-RENDERER") {
-                    break;
-                }
-
+            let i = scrapeStartingIndex;
+            while (i < elementCollection.length && elementCollection[i].nodeName != "YTMUSIC-CONTINUATION-ITEM-RENDERER") {
                 const elementMetadata = scrapeElementFunction(elementCollection[i]); // Scrape the metadata from the element
-                results.push(elementMetadata); // If the metadata has valid data, add it to the results array
-
-                // if (typeof elementMetadata.title === "undefined") {
-                //     console.log("problematic index is " + i);
-                // }
+                results.push(elementMetadata); // Add the metadata to the results array
+                i++;
             }
+
+            // do {
+            //     const elementMetadata = scrapeElementFunction(elementCollection[i]); // Scrape the metadata from the element
+            //     results.push(elementMetadata); // If the metadata has valid data, add it to the results array
+            //     i++;
+            //   } while (i < elementCollection.length && elementCollection[i].nodeName != "YTMUSIC-CONTINUATION-ITEM-RENDERER");
+
+            // for (let i = scrapeStartingIndex; i < elementCollection.length; i++) { // For each new element loaded in the DOM...
+            //     // Ignore the "continuation" element at the end of each batch of loaded elements. It's possible this YTM behavior will change in the future.
+            //     if (elementCollection[i].nodeName == "YTMUSIC-CONTINUATION-ITEM-RENDERER") {
+            //         break;
+            //     }
+
+            //     const elementMetadata = scrapeElementFunction(elementCollection[i]); // Scrape the metadata from the element
+            //     results.push(elementMetadata); // If the metadata has valid data, add it to the results array
+            // }
 
             if (results.length === expectedElementCount) { // If there is an expected element count and it matches the length of the metadata array...
                 // Note: This currently works for the 'Your Likes' list even though the expected/displayed track count is incorrect. This is is because the displayed track count is greater than the actual one. If it was the other way around, it's possible the resulting scraped tracklist could be incorrect.

--- a/scripts/content-scripts/utilities.js
+++ b/scripts/content-scripts/utilities.js
@@ -28,23 +28,38 @@ function scrapeElements (scrollContainer, elementContainer, scrapeStartingIndex,
         const scrapeLoadedElements = () => { // Set up the function to scrape the set of elements most recently loaded in the DOM
             clearTimeout(scrollingTimeoutID); // Since there are still elements available to scrape, clear the timeout that would otherwise end the scrolling process after a few seconds. The timeout will be reset if the scrape isn't complete after the upcoming scrape.        
             
-            for (let i = scrapeStartingIndex; i < (elementCollection.length); i++) { // For each new element loaded in the DOM...
-                const elementMetadata = scrapeElementFunction(elementCollection[i]); // Scrape the metadata from the element
+            console.info(`Current element collection length is ${elementCollection.length}`);
+
+            for (let i = scrapeStartingIndex; i < elementCollection.length; i++) { // For each new element loaded in the DOM...
+                if (i === scrapeStartingIndex || i % 100 !== 0) {
+                    const elementMetadata = scrapeElementFunction(elementCollection[i]); // Scrape the metadata from the element
+                    results.push(elementMetadata); // If the metadata has valid data, add it to the results array
+
+                    if (typeof elementMetadata.title === "undefined") {
+                        console.log("problematic index is " + i);
+                    }
+                }
+                
+                // const elementMetadata = scrapeElementFunction(elementCollection[i]); // Scrape the metadata from the element
 
                 // if (typeof elementMetadata.title === "undefined") {
-
+                //     console.log("problematic index is " + i);
                 // }
 
-                if (typeof elementMetadata.title !== "undefined") {
-                    results.push(elementMetadata); // If the metadata has valid data, add it to the results array
-                }
+                
+
+                // if (typeof elementMetadata.title !== "undefined") {
+                //     results.push(elementMetadata); // If the metadata has valid data, add it to the results array
+                // }
                 //results.push(scrapeElementFunction(elementCollection[i])); // Scrape the metadata from the element and add it to the metadata array
             }
 
             if (results.length === expectedElementCount) { // If there is an expected element count and it matches the length of the metadata array...
                 // Note: This currently works for the 'Your Likes' list even though the expected/displayed track count is incorrect. This is is because the displayed track count is greater than the actual one. If it was the other way around, it's possible the resulting scraped tracklist could be incorrect.
+                console.info(`Scrape ended. ${results.length} results scraped out of an expected ${expectedElementCount}.`);
                 endScrape(); // End the scrape
             } else { // Else, if the scrape isn't complete or the expected element count is unknown...
+                console.info(`Scrape is incomplete and will continue. ${results.length} results scraped out of an expected ${expectedElementCount}.`);
                 scrollToElement(elementCollection[elementCollection.length-1]); // Scroll to the last available child element in the container
                 scrapeStartingIndex = elementCollection.length-1; // Set the starting index for the next scrape to be one greater than the index of the last child element from the previous scrape
                 scrollingTimeoutID = setTimeout(endScrape, 10000); // Set a timeout to end the scrolling if no new changes to the container element have been observed for a while. This avoids infinite scrolling when the expected element count is unknown, or if an unexpected issue is encountered.
@@ -67,58 +82,6 @@ function scrapeElements (scrollContainer, elementContainer, scrapeStartingIndex,
         triggerDelayedScrape(); // Wait a short amount of time to allow the page to scroll to the top of the tracklist, and then begin the scrape & scroll process
     });
 }
-
-// /**
-//  * Runs through a process that scrolls through the given list of elements and scrapes metadata out of each of the elements
-//  * @param {Object} scrollContainer The element which needs to be scrolled in order to load all relevant child elements
-// * @param {Object} elementContainer The container element wrapping all the individual elements to scrape
-//  * @param {number} scrapeStartingIndex The index within the container element at which to begin the initial scrape
-//  * @param {function} scrapeElementFunction The function to execute on each individual element to extract metadata from it
-//  * @param {number} [expectedElementCount] An optional parameter indicating the expected element count for the list, if available
-//  * @returns {Object[]} An array of the metadata scraped from each element
-//  */
-// async function asyncScrapeElements(scrollContainer, elementContainer, scrapeStartingIndex, scrapeElementFunction, expectedElementCount) {
-//     const elementCollection = elementContainer.children;
-//     const results = []; // Create an array to store the metadata scraped from each element in the list
-//     let scrollingTimeoutID = undefined; // Variable tracking the timeout to end the scroll & scrape process, in case no changes to the container element are observed for a while
-
-//     const triggerDelayedScrape = (delay=100) => setTimeout(scrapeLoadedElements, delay); // Set up the function to trigger a scrape of the loaded element after a brief delay. This allows time for all the sub-elements in the DOM to load.
-
-//     const scrapeLoadedElements = () => { // Set up the function to scrape the set of elements most recently loaded in the DOM
-//         clearTimeout(scrollingTimeoutID); // Since there are still elements available to scrape, clear the timeout that would otherwise end the scrolling process after a few seconds. The timeout will be reset if the scrape isn't complete after the upcoming scrape.        
-        
-//         for (let i = scrapeStartingIndex; i < (elementCollection.length); i++) { // For each new element loaded in the DOM...
-//             results.push(scrapeElementFunction(elementCollection[i])); // Scrape the metadata from the element and add it to the metadata array
-//         }
-
-//         if (results.length === expectedElementCount) { // If there is an expected element count and it matches the length of the metadata array...
-//             // Note: This currently works for the 'Your Likes' list even though the expected/displayed track count is incorrect. This is is because the displayed track count is greater than the actual one. If it was the other way around, it's possible the resulting scraped tracklist could be incorrect.
-//             endScrape(); // End the scrape
-//         } else { // Else, if the scrape isn't complete or the expected element count is unknown...
-//             scrollToElement(elementCollection[elementCollection.length-1]); // Scroll to the last available child element in the container
-//             scrapeStartingIndex = elementCollection.length; // Set the starting index for the next scrape to be one greater than the index of the last child element from the previous scrape
-//             scrollingTimeoutID = setTimeout(endScrape, 10000); // Set a timeout to end the scrolling if no new changes to the container element have been observed for a while. This avoids infinite scrolling when the expected element count is unknown, or if an unexpected issue is encountered.
-//         }
-//     }
-
-//     const endScrape = () => { // Set up the function to execute once the scrape & scroll process has either been successfully completed or timed out
-//         allowManualScrolling(scrollContainer, true); // Allow the user to scroll manually again
-//         observer.disconnect(); // Disconnect the mutation observer
-//         return results; // Return the resulting array of scraped metadata
-//     }
-
-//     allowManualScrolling(scrollContainer, false); //Temporarily disable manual scrolling to avoid any interference from the user during the scrape process
-//     scrollToTopOfContainer(scrollContainer); //Scroll to the top of the tracklist, as an extra safety measure just to be certain that no tracks are missed in the scrape. (Note: This step likely isn't necessary in YTM since it appears the track row elements never get removed from the DOM no matter how far down a list you scroll).
-
-//     const observer = new MutationObserver(triggerDelayedScrape); // Create a new mutation observer instance which triggers a scrape of the loaded elements after a brief delay (which allows time for all the sub-elements in the DOM to load).
-//     const observerConfig = {childList: true}; // Set up the configuration options for the Mutation Observer to watch for changes to the element's childList
-//     observer.observe(elementContainer, observerConfig); // Start observing the container element for configured mutations (i.e. for any changes to its childList)
-    
-//     triggerDelayedScrape(); // Wait a short amount of time to allow the page to scroll to the top of the tracklist, and then begin the scrape & scroll process
-
-//     // await console.log("Awaiting");
-//     // console.log("awaited");
-// }
 
 /**** Helpers ****
 

--- a/scripts/content-scripts/utilities.js
+++ b/scripts/content-scripts/utilities.js
@@ -30,6 +30,7 @@ function scrapeElements (scrollContainer, elementContainer, scrapeStartingIndex,
             console.info(`Current element collection length is ${elementCollection.length}`);
 
             let i = scrapeStartingIndex;
+            // Scrape through the latest batch of loaded elements, ignoring the "continuation" element at the end of each batch. It's possible this YTM behavior will change in the future.
             while (i < elementCollection.length && elementCollection[i].nodeName != "YTMUSIC-CONTINUATION-ITEM-RENDERER") {
                 const elementMetadata = scrapeElementFunction(elementCollection[i]); // Scrape the metadata from the element
                 results.push(elementMetadata); // Add the metadata to the results array

--- a/scripts/content-scripts/ytm-dom-scraper.js
+++ b/scripts/content-scripts/ytm-dom-scraper.js
@@ -2,8 +2,12 @@
 const header = document.querySelector('ytmusic-responsive-header-renderer');
 const scrollContainer = document.body;
 
-observeHeaderElementMutations(); // Begin observing the YTM Header element for DOM mutations
-scrapeTracklistMetadata(); // Scrape the header element for tracklist metadata. (This needs to be manually triggered the first time the content script runs e.g. on page refresh)
+init();
+
+function init() {
+    observeHeaderElementMutations(); // Begin observing the YTM Header element for DOM mutations
+    scrapeTracklistMetadata(); // Scrape the header element for tracklist metadata. (This needs to be manually triggered the first time the content script runs e.g. on page refresh)
+}
 
 function observeHeaderElementMutations() {    
     // TODO something changed in the YTM implementation and switching from an invalid page (e.g. not a playlist) to a valid one is not properly registered. Not sure if the issue is here or in background.js


### PR DESCRIPTION
When scraping through a batch of loaded track elements, ignore the "continuation" element at the end of each batch. This is done to account for a somewhat recent change in the YTM DOM structure, and it's possible this behavior will change again in the future.

Also moved the initial logic in ytm-dom-scraper.js to an init() function and moved the message listener to the top of the file.